### PR TITLE
rename frontend service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
     environment:
       - FLASK_APP=api.py
       - FLASK_DEBUG=1
-      - DATADOG_SERVICE_NAME=iot-frontend
+      - DATADOG_SERVICE_NAME=frontend
       - DATADOG_TRACE_AGENT_HOSTNAME=agent
       - DD_LOGS_INJECTION=true
       - DD_ANALYTICS_ENABLED=true
@@ -37,7 +37,7 @@ services:
       - agent
       - db
     labels:
-      com.datadoghq.ad.logs: '[{"source": "python", "service": "iot-frontend"}]'
+      com.datadoghq.ad.logs: '[{"source": "python", "service": "frontend"}]'
   noder:
     environment:
       - DD_SERVICE_NAME=users-api


### PR DESCRIPTION
The service name `iot-frontend` is confusing, let's call it `frontend` instead so that it matches the folder where the code is.